### PR TITLE
Incorrect example for match all

### DIFF
--- a/docs/log-routing.md
+++ b/docs/log-routing.md
@@ -190,5 +190,5 @@ We recommend starting with a more restrictive selector to avoid filling up the b
     outputRefs:
       - forward-output-sample
     match:
-      select: {}
+      - select: {}
 ```


### PR DESCRIPTION
Example results in
```
rror: error validating "STDIN": error validating data: ValidationError(Flow.spec.match): invalid type for io.banzaicloud.logging.v1beta1.Flow.spec.match: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false
```

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline (TODO)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
