### PR TITLE
Fix links

### DIFF
--- a/docs/quickstarts/kafka-nginx.md
+++ b/docs/quickstarts/kafka-nginx.md
@@ -25,7 +25,7 @@ Install the Logging operator and a demo application to provide sample log messag
 
 ### Deploy the Logging operator with Helm
 
-To install the Logging operator using Helm, complete these steps. If you want to install the Logging operator using Kubernetes manifests, see [Deploy the Logging operator with Kubernetes manifests]({{< relref "docs/one-eye/logging-operator/deploy/_index.md#deploy-the-logging-operator-from-kubernetes-manifests" >}}).
+To install the Logging operator using Helm, complete these steps. If you want to install the Logging operator using Kubernetes manifests, see [Deploy the Logging operator with Kubernetes manifests]({{< relref "docs/one-eye/logging-operator/deploy/_index.md#deploy-with-manifest" >}}).
 
 1. Add the chart repository of the Logging operator using the following commands:
 
@@ -46,7 +46,7 @@ To install the Logging operator using Helm, complete these steps. If you want to
 
 To deploy the Logging operator using Kubernetes manifests, complete these steps. If you want to install the Logging operator using Helm, see [Deploy the Logging operator with Helm](#deploy-the-logging-operator-with-helm).
 
-1. Install the Logging operator. For details, see [How to install Logging-operator from manifests]({{< relref "docs/one-eye/logging-operator/deploy/_index.md#deploy-the-logging-operator-from-kubernetes-manifests" >}})
+1. Install the Logging operator. For details, see [How to install Logging-operator from manifests]({{< relref "docs/one-eye/logging-operator/deploy/_index.md#deploy-with-manifest" >}})
 1. Create the `logging` resource.
 
      ```yaml


### PR DESCRIPTION
Fixes
```
hash does not exist --- docs/one-eye/logging-operator/quickstarts/kafka-nginx/index.html --> /docs/one-eye/logging-operator/deploy/#deploy-the-logging-operator-from-kubernetes-manifests
```