### PR TITLE
Corrected the schema of the `mountFrom` secret definition example.

### DIFF
--- a/docs/configuration/plugins/outputs/secret.md
+++ b/docs/configuration/plugins/outputs/secret.md
@@ -29,10 +29,9 @@ There are cases when you can't inject secret into the configuration because the 
 
 ```yaml
 tls_cert_path:
-  valueFrom:
-    mountFrom:
-      name: <kubernetes-secret-name>
-      key: <kubernetes-secret-key>
+  mountFrom:
+    name: <kubernetes-secret-name>
+    key: <kubernetes-secret-key>
 ```
 
 The operator will collect the secret and copy it to the `fluentd-output` secret. The fluentd configuration will contain the secret path.
@@ -43,7 +42,7 @@ The operator will collect the secret and copy it to the `fluentd-output` secret.
     @type forward
     tls_cert_path /fluentd/etc/secret/default-fluentd-tls-tls.crt
     ...
-</match>     
+</match>
 ```
 
 ### How it works?
@@ -62,7 +61,7 @@ metadata:
 data:
   tls.crt: SGVsbG8gV29ybGQ=
 ```
- 
+
 > The annotation format is `logging.banzaicloud.io/<loggingRef>: watched`. Since the `name` part of the an annotation can't be empty the `default` applies to empty `loggingRef` value as well.
 
 The mount path is generated from the secret information


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Corrected the schema of the `mountFrom` secret definition example.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because the documentation contained an incorrect example according to the CRDs.
Noticed on the [documentation site](https://banzaicloud.com/docs/one-eye/logging-operator/plugins/outputs/secret/#define-secret-mount).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- ~Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)~
- [X] User guide and development docs updated (if needed)
- ~Related Helm chart(s) updated (if needed)~
