### PR TITLE
docs: add missing page metadata

### DIFF
--- a/docs/configuration/plugins/filters/throttle.md
+++ b/docs/configuration/plugins/filters/throttle.md
@@ -1,3 +1,9 @@
+---
+title: Throttle
+weight: 200
+generated_file: true
+---
+
 # [Throttle Filter](https://github.com/rubrikinc/fluent-plugin-throttle)
 ## Overview
  A sentry plugin to throttle logs. Logs are grouped by a configurable key. When a group exceeds a configuration rate, logs are dropped for this group.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
[Filters](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/plugins/filters/) page doesn't contain a title for the last item, I assume this is due to missing metadata.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
