### PR TITLE
Fix title of redis documentation

### DIFF
--- a/docs/configuration/plugins/outputs/redis.md
+++ b/docs/configuration/plugins/outputs/redis.md
@@ -1,5 +1,5 @@
 ---
-title: Http
+title: Redis
 weight: 200
 generated_file: true
 ---


### PR DESCRIPTION
While working with the logging operator documentation i saw that the http section was listed twice under the Outputs section. One of them links to the Redis docs. This PR tries to fix this by updating the title of the Redis documentation. I hope i found the right place in the code.
![redis-docs](https://user-images.githubusercontent.com/9465658/116866208-4f4d0f00-ac0b-11eb-885f-eb11601e49f3.png)
