### PR TITLE
Fix example in aws_elasticsearch output plugin

### DIFF
--- a/docs/configuration/plugins/outputs/aws_elasticsearch.md
+++ b/docs/configuration/plugins/outputs/aws_elasticsearch.md
@@ -11,9 +11,10 @@ generated_file: true
  #### Example output configurations
  ```
  spec:
-   kinesisStream:
-     stream_name: example-stream-name
-     region: us-east-1
+   awsElasticsearch:
+     endpoint:
+       url: https://example-es-url
+       region: us-east-1
      format:
        type: json
  ```


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
Fix up example for aws_elasticsearch.

### Why?
Seems someone just copy-pasted example from kinesisStream plugin, and that is not correct for aws elasticsearch plugin.

### Additional context


### Checklist

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)