### PR TITLE
[fix] Fields `hec_host` and `hec_port` in splunk example

### DIFF
--- a/docs/configuration/plugins/outputs/splunk_hec.md
+++ b/docs/configuration/plugins/outputs/splunk_hec.md
@@ -12,8 +12,8 @@ More info at https://github.com/splunk/fluent-plugin-splunk-hec
  ```
  spec:
    SplunkHec:
-     host: splunk.default.svc.cluster.local
-     port: 8088
+     hec_host: splunk.default.svc.cluster.local
+     hec_port: 8088
      protocol: http
  ```
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?

Updates the example in the Splunk docu to be correct.


### Why?

The field names were wrong and not consistent with the rest of the docu


### Additional context

N/A


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)
