### PR TITLE
[fix] Use lower case for `splunkHec`

### DIFF
--- a/docs/configuration/plugins/outputs/splunk_hec.md
+++ b/docs/configuration/plugins/outputs/splunk_hec.md
@@ -11,7 +11,7 @@ More info at https://github.com/splunk/fluent-plugin-splunk-hec
  #### Example output configurations
  ```
  spec:
-   SplunkHec:
+   splunkHec:
      hec_host: splunk.default.svc.cluster.local
      hec_port: 8088
      protocol: http


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?

Another typo in the docu for Splunk


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Using upper case `s` as in `SplunkHec` gives me an error


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Relates to https://github.com/banzaicloud/logging-operator-docs/pull/80

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)


