### PR TITLE
Say that log_group_name is required for Cloudwatch output config

### DIFF
--- a/docs/configuration/plugins/outputs/cloudwatch.md
+++ b/docs/configuration/plugins/outputs/cloudwatch.md
@@ -126,7 +126,7 @@ Specified field of records as AWS tags for the log group<br>
 
 Default: -
 
-### log_group_name (string, optional) {#output config-log_group_name}
+### log_group_name (string, required) {#output config-log_group_name}
 
 Name of log group to store logs<br>
 


### PR DESCRIPTION
We found that the Cloudwatch Output config is not functional if the log_group_name is not provided. https://github.com/rancher/dashboard/issues/3988

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://github.com/rancher/dashboard/issues/3988
| License         | Apache 2.0


### What's in this PR?
Marks a required field as required


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
