### PR TITLE
add fluentbit mountPath configuration doc

### DIFF
--- a/docs/configuration/fluentbit.md
+++ b/docs/configuration/fluentbit.md
@@ -52,6 +52,22 @@ spec:
   controlNamespace: logging
 ```
 
+## Log Mount Path
+
+If the container logs of your k8s cloud provider or deployed k8s environment are not saved in the default directory, you can use the mountPath field to modify. For example:
+
+```yaml
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: default-logging-simple
+spec:
+  fluentd: {}
+  fluentbit:
+    mountPath: /data/docker/containers
+  controlNamespace: logging
+```
+
 For the detailed list of available parameters for this plugin, see {{% xref "/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentbit_types.md#inputtail" %}}.
 [More Info](https://github.com/fluent/fluent-bit-docs/blob/1.3/input/tail.md).
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
There is no detailed description of the mountPath configuration item of fluentbit in the document. Since my k8s cloud provider log storage directory is not in the default path, the log cannot be collected. After modifying this item, the log can be collected successfully


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [ ] User guide and development docs updated (if needed)
- [ ] Related Helm chart(s) updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
